### PR TITLE
Override padding for latest comments block to be consistent with latest posts

### DIFF
--- a/theme/css/b5st.css
+++ b/theme/css/b5st.css
@@ -28,6 +28,9 @@ ul.wp-block-latest-posts.is-grid.alignwide,
 ul.wp-block-latest-posts.is-grid.alignwide {
   padding: 0 16px; }
 
+ol.wp-block-latest-comments {
+  padding-left: 0; }
+
 header h2 a {
   color: rgba(0, 0, 0, 0.9);
   text-decoration: none; }

--- a/theme/scss/b5st/_base.scss
+++ b/theme/scss/b5st/_base.scss
@@ -66,3 +66,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   padding: 0 16px;
 }
 
+// Latest Comments
+ol.wp-block-latest-comments {
+  padding-left: 0;
+}


### PR DESCRIPTION
Resolves #5
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/49364385/219853375-2f295612-6bbb-44a5-b2dd-38848d385a90.png">
